### PR TITLE
add instruction on macOS installation

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -17,6 +17,7 @@ Then, we address how to work with [Jupyter](https://jupyter.org/) notebooks to v
     - it pulls the image from the Docker Hub account `appliedai` and the repository `packt` with the tag `latest`
     - creates a local container with the name `ml4t` and runs it in interactive mode, forwarding the port 8888 used by the `jupyter` server
     - mounts the current directory containing the starter project files as a volume in the directory `/home/packt/ml4t` inside the container
+    - after adding the folder, restarting both terminal and docker
     - sets the environment variable `QUANDL_API_KEY` with the value of your key (that you need to fill in for `<your API key>`), and
     - starts a `bash` terminal inside the container, resulting in a new command prompt for the user `packt`.
 4. Now you are running a shell inside the container and can access the `conda environments`.


### PR DESCRIPTION
I am using macOS Catalina Version is 10.15.7

After I type the command: 
`docker run -it -v $(pwd):/home/packt/ml4t -p 8888:8888 -e QUANDL_API_KEY=<your API key> --name ml4t appliedai/packt:latest bash
`
The terminal will display errors: 
docker: Error response from daemon: Mounts denied: 
The paths /var/folders/xx/... and /var/folders/xx/...
are not shared from OS X and are not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.

And after I setup the folder sharing in docker by using setting button, delete the newly created image in docker, and try again using the command above, it is still showing the same error. But I solve the error by restart the docker and terminal.
Hope this instruction could be added into the installation.